### PR TITLE
Standardize code and fix warnings

### DIFF
--- a/benchmarks/prefetch/prefetchBench.cpp
+++ b/benchmarks/prefetch/prefetchBench.cpp
@@ -1,10 +1,10 @@
 /**
- * prefetchBench.cpp - 
+ * prefetchBench.cpp -
  * @author: Jonathan Beard
  * @version: Fri Mar 25 14:49:51 2016
- * 
+ *
  * Copyright 2016 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -55,10 +55,11 @@ static void fun_function( FUNCTION function,
 template < std::size_t N > struct foo
 {
    constexpr foo() : length( N ){}
-   
+
    foo( const foo &other ) : length( other.length )
    {
-        for( auto i( 0 ); i < N; i++ )
+        using index_type = std::remove_const_t<decltype(N)>;
+        for( index_type i( 0 ); i < N; i++ )
         {
             pad[ i ] = other.pad[ i ];
         }
@@ -86,10 +87,13 @@ public:
     virtual raft::kstatus run()
     {
         auto &mem( output[ "y" ].allocate< obj_t >() );
-        for( auto i( 0 ); i < mem.length; i++ )
+
+        using index_type = std::remove_const_t<decltype(mem.length)>;
+        for( index_type i( 0 ); i < mem.length; i++ )
         {
             mem.pad[ i ] = counter;
         }
+
         output[ "y" ].send();
         counter++;
         if( counter == 100000 )
@@ -110,7 +114,7 @@ public:
     {
         input.addPort< obj_t >( "in" );
         output.addPort< obj_t >( "out" );
-#ifdef PAPITEST        
+#ifdef PAPITEST
         //set up PAPI
         fun_function( PAPI_library_init,
                       PAPI_VER_CURRENT,
@@ -142,7 +146,7 @@ public:
                       __FILE__,
                       __LINE__,
                       EventSet );
-#endif                      
+#endif
     }
 
 #ifdef PAPITEST
@@ -168,7 +172,7 @@ public:
     }
 #else
     virtual ~passthrough() = default;
-#endif                      
+#endif
 
     virtual raft::kstatus run()
     {
@@ -183,7 +187,7 @@ public:
         return( raft::proceed );
     }
 
-#ifdef PAPITEST    
+#ifdef PAPITEST
 private:
     int EventSet = PAPI_NULL;
 #endif
@@ -211,7 +215,7 @@ private:
 
 
 
-int 
+int
 main( int argc, char **argv )
 {
     start st;
@@ -219,7 +223,7 @@ main( int argc, char **argv )
     last l;
 
     raft::map m;
-    m += st >> pt >> l; 
+    m += st >> pt >> l;
     m.exe();
     return( EXIT_SUCCESS );
 }

--- a/examples/general/readfile/readtest.cpp
+++ b/examples/general/readfile/readtest.cpp
@@ -7,7 +7,7 @@ int
 main( int argc, char **argv )
 {
    using chunk = raft::filechunk< 1024 >;
-   using fr = raft::filereader< chunk, false >; 
+   using fr = raft::filereader< chunk, false >;
    using pr = raft::print< chunk >;
    fr reader( argv[ 1 ] );
    pr printer;
@@ -15,6 +15,6 @@ main( int argc, char **argv )
    raft::map m;
    m += reader >> printer;
    m.exe();
-   
+
    return( EXIT_SUCCESS );
-};
+}

--- a/raftinc/blocked.hpp
+++ b/raftinc/blocked.hpp
@@ -1,10 +1,10 @@
 /**
- * blocked.hpp - 
+ * blocked.hpp -
  * @author: Jonathan Beard
  * @version: Sun Jun 29 14:06:10 2014
- * 
+ *
  * Copyright 2014 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -23,30 +23,30 @@
 
 union Blocked
 {
-   
+
    Blocked() : all( 0 )
    {}
 
    Blocked( volatile Blocked &other )
    {
-      count    = other.count;
-      blocked  = other.blocked;
+      bec.count    = other.bec.count;
+      bec.blocked  = other.bec.blocked;
    }
 
    Blocked& operator += ( const Blocked &rhs )
    {
-      if( ! rhs.blocked )
+      if( ! rhs.bec.blocked )
       {
-         (this)->count += rhs.count;
+         (this)->bec.count += rhs.bec.count;
       }
       return( *this );
    }
-   
-   struct
+
+   struct blocked_and_counter
    {
       std::uint32_t blocked;
       std::uint32_t count;
-   };
+   } bec;
    std::uint64_t all;
 }
 #if __APPLE__ || __linux

--- a/raftinc/join.tcc
+++ b/raftinc/join.tcc
@@ -1,10 +1,10 @@
 /**
- * join.tcc - 
+ * join.tcc -
  * @author: Jonathan Beard
  * @version: Tue Oct 28 12:51:49 2014
- * 
+ *
  * Copyright 2014 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -30,7 +30,9 @@ public:
    join( const std::size_t num_ports = 1 ) : parallel_k()
    {
       output.addPort< T >( "0" );
-      for( auto it( 0 ); it < num_ports; it++ )
+
+      using index_type = std::remove_const_t<decltype(num_ports)>;
+      for( index_type it( 0 ); it < num_ports; it++ )
       {
          addPort();
       }
@@ -55,7 +57,7 @@ public:
       }
       return( raft::proceed );
    }
-   
+
    virtual std::size_t  addPort()
    {
       return( (this)->addPortTo< T >( input ) );
@@ -65,15 +67,15 @@ public:
 protected:
    virtual void lock()
    {
-      lock_helper( input ); 
-   }
-   
-   virtual void unlock()
-   {
-      unlock_helper( input ); 
+      lock_helper( input );
    }
 
-   method split_func; 
+   virtual void unlock()
+   {
+      unlock_helper( input );
+   }
+
+   method split_func;
 };
 }
 #endif /* END _JOIN_TCC_ */

--- a/raftinc/kset.tcc
+++ b/raftinc/kset.tcc
@@ -5,9 +5,9 @@
  *
  * @author: Jonathan Beard
  * @version: Wed Apr 13 12:50:38 2016
- * 
+ *
  * Copyright 2016 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -37,7 +37,7 @@ namespace raft
 /** predeclare raft::kernel **/
 class kernel;
 
-/** 
+/**
  * dummy class for extending to kset, largely used
  * to keep from having to type out the class type
  * in long form within the kpair/map classes.
@@ -45,7 +45,7 @@ class kernel;
 struct basekset{
     constexpr basekset() = delete;
     ~basekset() = delete;
-    
+
     using iterator_t = typename
         std::vector< std::reference_wrapper< raft::kernel > >::iterator;
 
@@ -57,23 +57,23 @@ struct basekset{
 template < class... KERNELS > struct AddKernel;
 
 /**
- * feel hacky doing this, but it's probably the 
+ * feel hacky doing this, but it's probably the
  * least amount of code I can write to get this
  * done....probably better way using a tuple
- * like construct, then the compiler would do 
- * most of the work 
+ * like construct, then the compiler would do
+ * most of the work
  */
 
-template < class... K > class ksetr 
+template < class... K > class ksetr
 #ifndef TEST_WO_RAFT
-: public basekset 
+: public basekset
 #endif
 {
 private:
     static_assert( sizeof...( K ) > 0, "size for kset must be > 0" );
     using common_t = typename std::common_type< K... >::type;
-#ifndef TEST_WO_RAFT    
-    /** 
+#ifndef TEST_WO_RAFT
+    /**
      * interestingly this class is far more generic, but for RaftLib
      * we need the common_t to be either raft::kernel, or a dervied
      * type of raft::kernel
@@ -81,17 +81,17 @@ private:
     static_assert( std::is_base_of< basekset,
                                     common_t >::value,
                    "The common type of ksetr must be a derived class of raft::kernel" );
-#endif                   
+#endif
     /** don't want to type this over and over **/
     using vector_t = std::vector< std::reference_wrapper< common_t > >;
     vector_t  k;
-    
+
 public:
     /**
-     * base constructor, with multiple args. 
+     * base constructor, with multiple args.
      */
     constexpr
-    ksetr( K&... kernels ) 
+    ksetr( K&... kernels )
     {
         /**
          * until we get the tuple-like solution built, dynamic alloc
@@ -101,7 +101,7 @@ public:
         k.reserve( sizeof...( K ) );
         AddKernel< K... >::add( std::forward< K >( kernels )..., k );
     }
-  
+
     /**
      * move constructor, hopefully keep the dynamic mem
      * in vector valid w/o re-allocating and copying.
@@ -131,7 +131,7 @@ public:
      * default destructor, nothing really to destruct
      */
     virtual ~ksetr() = default;
-    
+
     /**
      * get the number of kernels held.
      */
@@ -151,15 +151,15 @@ public:
  */
 template < class K, class... KS > struct AddKernel< K, KS... >
 {
-    template < class CONTAINER > 
-        static void add( K &&kernel, 
-                         KS&&... kernels, 
+    template < class CONTAINER >
+        static void add( K &&kernel,
+                         KS&&... kernels,
                          CONTAINER &c )
     {
         c.emplace_back( kernel );
         AddKernel< KS... >::add( std::forward< KS >( kernels )..., c );
         return;
-    };
+    }
 };
 
 /**
@@ -168,21 +168,21 @@ template < class K, class... KS > struct AddKernel< K, KS... >
  */
 template < class K > struct AddKernel< K >
 {
-    template < class CONTAINER > 
+    template < class CONTAINER >
         static void add( K &&kernel, CONTAINER &c )
     {
         c.emplace_back( kernel );
         return;
-    };
+    }
 };
 
-/** 
- * wrap so I can get away w/o having to do the class vs. constructor 
+/**
+ * wrap so I can get away w/o having to do the class vs. constructor
  * template args
  */
-template< class... K > 
+template< class... K >
 inline
-static 
+static
 ksetr< K... >
 kset( K&&... kernels )
 {

--- a/raftinc/lambdak.tcc
+++ b/raftinc/lambdak.tcc
@@ -1,10 +1,10 @@
 /**
- * lambdak.tcc - 
+ * lambdak.tcc -
  * @author: Jonathan Beard
  * @version: Thu Oct 30 10:12:36 2014
- * 
+ *
  * Copyright 2014 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -27,7 +27,7 @@
 namespace raft
 {
 /** TODO, this needs some more error checking before production **/
-   
+
 /** pre-declare recursive struct / functions **/
 template < class... PORTSL > struct AddPorts;
 template < class... PORTSK > struct AddSamePorts;
@@ -36,33 +36,33 @@ template < class... PORTS >
    class lambdak : public raft::kernel
 {
 public:
-   typedef std::function< raft::kstatus ( Port &input, 
+   typedef std::function< raft::kstatus ( Port &input,
                                           Port &output ) > lambdafunc_t;
    /**
-    * constructor - 
+    * constructor -
     * @param   inputs - const std::size_t number of inputs to the kernel
     * @param   outputs - const std::size_t number of outputs to the kernel
     * @param   func - static or lambda function to execute.
     */
-   lambdak( const std::size_t inputs, 
-            const std::size_t outputs, 
+   lambdak( const std::size_t inputs,
+            const std::size_t outputs,
             lambdafunc_t  func ) :   raft::kernel(),
                                      run_func( func )
    {
       add_ports< PORTS... >( inputs, outputs );
    }
 
-    
-    //FIXME, add copy constructor    
+
+    //FIXME, add copy constructor
 
 
    /**
-    * run - implement the run function for this kernel, 
+    * run - implement the run function for this kernel,
     */
    virtual raft::kstatus run()
    {
-      return( run_func( input  /** input ports **/, 
-                        output /** output ports **/) ); 
+      return( run_func( input  /** input ports **/,
+                        output /** output ports **/) );
    }
 
 
@@ -71,23 +71,23 @@ private:
    /** lambda func passed by user **/
    lambdafunc_t  run_func;
 
-   
+
    /** function **/
    template < class... PORTSM >
-      void add_ports( const std::size_t input_max, 
+      void add_ports( const std::size_t input_max,
                       const std::size_t output_max )
    {
       const auto num_types( sizeof... (PORTSM) );
       if( num_types == 1 )
       {
          /** everybody gets same type, add here **/
-         AddSamePorts< PORTSM... >::add( input_max     /* count */, 
+         AddSamePorts< PORTSM... >::add( input_max     /* count */,
                                          input         /* in-port obj */,
                                          output_max    /* count */,
                                          output        /* out-port obj */ );
       }
       /** no idea what type each port is, throw error **/
-      else if( num_types != (input_max + output_max ) ) 
+      else if( num_types != (input_max + output_max ) )
       {
          /** TODO, make exception for here **/
          assert( false );
@@ -98,10 +98,10 @@ private:
          std::size_t input_index(  0 );
          std::size_t output_index( 0 );
          AddPorts< PORTSM... >::add( input_index,
-                                     input_max, 
-                                     input /* ports */, 
+                                     input_max,
+                                     input /* ports */,
                                      output_index,
-                                     output_max, 
+                                     output_max,
                                      output /* ports */);
       }
    }
@@ -109,14 +109,14 @@ private:
 
 
 }; /** end template lambdak **/
-   
+
 /** class recursion **/
 template < class PORT, class... PORTSL > struct AddPorts< PORT, PORTSL...>
 {
-   static void add( std::size_t &input_index, 
+   static void add( std::size_t &input_index,
                     const std::size_t input_max,
                     Port &input_ports,
-                    std::size_t &output_index, 
+                    std::size_t &output_index,
                     const std::size_t output_max,
                     Port &output_ports )
    {
@@ -144,9 +144,9 @@ template < class PORT, class... PORTSL > struct AddPorts< PORT, PORTSL...>
       }
       else
       {
-         /** 
+         /**
           * I think it'll be okay here simply to return, however
-          * we might need the blank specialization below 
+          * we might need the blank specialization below
           */
       }
       return;
@@ -173,11 +173,14 @@ template < class PORT, class... PORTSK > struct AddSamePorts< PORT, PORTSK... >
    static void add( const std::size_t input_count, Port &inputs,
                     const std::size_t output_count, Port &outputs )
    {
-      for( auto it( 0 ); it < input_count; it++ )
+      using input_index_type = std::remove_const_t<decltype(input_count)>;
+      for( input_index_type it( 0 ); it < input_count; it++ )
       {
          inputs.addPort< PORT >( std::to_string( it ) );
       }
-      for( auto it( 0 ); it < output_count; it++ )
+
+      using output_index_type = std::remove_const_t<decltype(input_count)>;
+      for( output_index_type it( 0 ); it < output_count; it++ )
       {
          outputs.addPort< PORT >( std::to_string( it ) );
       }

--- a/raftinc/raftmath.tcc
+++ b/raftinc/raftmath.tcc
@@ -1,10 +1,10 @@
 /**
- * raftmath.tcc - 
+ * raftmath.tcc -
  * @author: Jonathan Beard
  * @version: Tue Apr 28 13:48:37 2015
- * 
+ *
  * Copyright 2015 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -42,8 +42,8 @@ template < class RETTYPE, class PORT, class... PORTS >
    {
       RETTYPE val;
       port.pop( val );
-      return(  std::move< RETTYPE >( 
-                  val + sum_helper< RETTYPE, PORTS... >::sum( 
+      return(  std::move< RETTYPE >(
+                  val + sum_helper< RETTYPE, PORTS... >::sum(
                      std::forward< PORTS >( ports )... ) ) );
    }
 };
@@ -54,12 +54,12 @@ template < class RETTYPE, class PORT, class... PORTS >
  */
 template < typename RETTYPE,
            class... PORTS,
-        typename std::enable_if< std::is_arithmetic< RETTYPE >::value >::type* = nullptr 
+        typename std::enable_if< std::is_arithmetic< RETTYPE >::value >::type* = nullptr
            > static RETTYPE sum(  PORTS&&... ports )
 {
-   return( std::move< RETTYPE >( sum_helper< RETTYPE, PORTS... >::sum( 
-               std::forward< PORTS >( ports )... ) ) ); 
-};
+   return( std::move< RETTYPE >( sum_helper< RETTYPE, PORTS... >::sum(
+               std::forward< PORTS >( ports )... ) ) );
+}
 
 /** START recursive templates for mult **/
 template < class RETTYPE, class... PORTS > struct mult_helper{};
@@ -79,8 +79,8 @@ template < class RETTYPE, class PORT, class... PORTS >
    {
       RETTYPE val;
       port.pop( val );
-      return(  std::move< RETTYPE >( 
-                  val * mult_helper< RETTYPE, PORTS... >::mult( 
+      return(  std::move< RETTYPE >(
+                  val * mult_helper< RETTYPE, PORTS... >::mult(
                      std::forward< PORTS >( ports )... ) ) );
    }
 };
@@ -91,12 +91,12 @@ template < class RETTYPE, class PORT, class... PORTS >
  */
 template < typename RETTYPE,
            class... PORTS,
-        typename std::enable_if< std::is_arithmetic< RETTYPE >::value >::type* = nullptr 
+        typename std::enable_if< std::is_arithmetic< RETTYPE >::value >::type* = nullptr
            > static RETTYPE mult(  PORTS&&... ports )
 {
-   return( std::move< RETTYPE >( mult_helper< RETTYPE, PORTS... >::mult( 
-            std::forward< PORTS >( ports )... ) ) ); 
-};
+   return( std::move< RETTYPE >( mult_helper< RETTYPE, PORTS... >::mult(
+            std::forward< PORTS >( ports )... ) ) );
+}
 
 
 } /** end namespace raft **/

--- a/raftinc/ringbuffer.tcc
+++ b/raftinc/ringbuffer.tcc
@@ -1,10 +1,10 @@
 /**
- * ringbuffer.tcc - 
+ * ringbuffer.tcc -
  * @author: Jonathan Beard
  * @version: Wed Apr 16 14:18:43 2014
- * 
+ *
  * Copyright 2014 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -18,18 +18,18 @@
  * limitations under the License.
  */
 #ifndef _RINGBUFFER_TCC_
-#define _RINGBUFFER_TCC_  1
+#define _RINGBUFFER_TCC_ 1
 
 #include <array>
-#include <cstdlib>
-#include <thread>
-#include <cstring>
-#include <cstdint>
-#include <vector>
-#include <iostream>
-#include <fstream>
-#include <utility>
 #include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <thread>
+#include <utility>
+#include <vector>
 
 #include "ringbufferbase.tcc"
 #include "ringbuffertypes.hpp"
@@ -42,103 +42,92 @@
 /**
  * RingBuffer, default type is a heap.  This version
  * has no "monitor" thread, but does have the ability
- * to query queue size which can be quite useful for 
- * some monitoring tasks. 
+ * to query queue size which can be quite useful for
+ * some monitoring tasks.
  */
-template < class T, 
-           Type::RingBufferType type = Type::Heap, 
-           bool monitor = false >  class RingBuffer : 
-               public RingBufferBase< T, type >
+template <class T, Type::RingBufferType type = Type::Heap, bool monitor = false>
+class RingBuffer : public RingBufferBase<T, type>
 {
 public:
-   /**
-    * RingBuffer - default constructor, initializes basic
-    * data structures.
-    */
-   RingBuffer( const std::size_t n, 
-               const std::size_t align = 16 ) : 
-      RingBufferBase< T, type >()
-   {
-      assert( n != 0 );
-      (this)->datamanager.set( new Buffer::Data<T, type >( n, align ) );
-   }
-   
-   /**
-    * RingBuffer - default constructor, initializes basic
-    * data structures.
-    */
-   RingBuffer( void * const      ptr, 
-               const std::size_t length,
-               const std::size_t start_position ) : 
-      RingBufferBase< T, type >()
-   {
-      assert( length != 0 );
-      T *ptrcast = reinterpret_cast< T* >( ptr );
-      (this)->datamanager.set( 
-        new Buffer::Data<T, type >( ptrcast, length, start_position ) );
-   }
+    /**
+     * RingBuffer - default constructor, initializes basic
+     * data structures.
+     */
+    RingBuffer(const std::size_t n, const std::size_t align = 16)
+        : RingBufferBase<T, type>()
+    {
+        assert(n != 0);
+        (this)->datamanager.set(new Buffer::Data<T, type>(n, align));
+    }
 
-   virtual ~RingBuffer()
-   {
-      /** TODO, might need to get a lock here **/
-      /** might have bad behavior if we double delete **/
-      delete( (this)->datamanager.get() );
-   }
+    /**
+     * RingBuffer - default constructor, initializes basic
+     * data structures.
+     */
+    RingBuffer(void* const ptr, const std::size_t length,
+        const std::size_t start_position)
+        : RingBufferBase<T, type>()
+    {
+        assert(length != 0);
+        T* ptrcast = reinterpret_cast<T*>(ptr);
+        (this)->datamanager.set(
+            new Buffer::Data<T, type>(ptrcast, length, start_position));
+    }
 
-   /**
-    * make_new_fifo - builder function to dynamically
-    * allocate FIFO's at the time of execution.  The
-    * first two parameters are self explanatory.  The
-    * data ptr is a data struct that is dependent on the
-    * type of FIFO being built.  In there really is no
-    * data necessary so it is expacted to be set to nullptr
-    * @param   n_items - std::size_t
-    * @param   align   - memory alignment
-    * @return  FIFO*
-    */
-   static FIFO* make_new_fifo( std::size_t n_items,
-                               std::size_t align,
-                               void * const data )
-   {
-      if( data != nullptr )
-      {
-         return( new RingBuffer< T, 
-                                 Type::Heap, 
-                                 false >( data, 
-                                          n_items, 
-                                          align /** actually start pos, redesign **/) );
-      }
-      else
-      {
-         return( new RingBuffer< T, 
-                                 Type::Heap, 
-                                 false >( n_items, align ) ); 
-      }
-   }
+    virtual ~RingBuffer()
+    {
+        /** TODO, might need to get a lock here **/
+        /** might have bad behavior if we double delete **/
+        delete((this)->datamanager.get());
+    }
 
-   virtual void resize( const std::size_t size,
-                        const std::size_t align,
-                        volatile bool &exit_alloc )
-   {
-      if( (this)->datamanager.is_resizeable() )
-      {
-         (this)->datamanager.resize( 
-            new Buffer::Data< T, type >( size, align ), exit_alloc );
-      }
-      /** else, not resizeable..just return **/
-      return;
-   }
-   
-   virtual float get_frac_write_blocked()
-   {
-      const auto copy( (this)->write_stats );
-      (this)->write_stats.all = 0;
-      if( copy.blocked == 0 || copy.count == 0 )
-      {
-         return( 0.0 );
-      }
-      return( (float) copy.blocked / (float) copy.count );
-   }
+    /**
+     * make_new_fifo - builder function to dynamically
+     * allocate FIFO's at the time of execution.  The
+     * first two parameters are self explanatory.  The
+     * data ptr is a data struct that is dependent on the
+     * type of FIFO being built.  In there really is no
+     * data necessary so it is expacted to be set to nullptr
+     * @param   n_items - std::size_t
+     * @param   align   - memory alignment
+     * @return  FIFO*
+     */
+    static FIFO* make_new_fifo(
+        std::size_t n_items, std::size_t align, void* const data)
+    {
+        if(data != nullptr)
+        {
+            return (new RingBuffer<T, Type::Heap, false>(
+                data, n_items, align /** actually start pos, redesign **/));
+        }
+        else
+        {
+            return (new RingBuffer<T, Type::Heap, false>(n_items, align));
+        }
+    }
+
+    virtual void resize(const std::size_t size, const std::size_t align,
+        volatile bool& exit_alloc)
+    {
+        if((this)->datamanager.is_resizeable())
+        {
+            (this)->datamanager.resize(
+                new Buffer::Data<T, type>(size, align), exit_alloc);
+        }
+        /** else, not resizeable..just return **/
+        return;
+    }
+
+    virtual float get_frac_write_blocked()
+    {
+        const auto copy((this)->write_stats);
+        (this)->write_stats.all = 0;
+        if(copy.bec.blocked == 0 || copy.bec.count == 0)
+        {
+            return (0.0);
+        }
+        return ((float)copy.bec.blocked / (float)copy.bec.count);
+    }
 };
 
 
@@ -146,319 +135,293 @@ public:
  * RingBufferBaseMonitor - encapsulates logic for a queue with
  * monitoring enabled.
  */
-template< class T, 
-          Type::RingBufferType type > class RingBufferBaseMonitor : 
-            public RingBufferBase< T, type >
+template <class T, Type::RingBufferType type>
+class RingBufferBaseMonitor : public RingBufferBase<T, type>
 {
 public:
-   RingBufferBaseMonitor( const std::size_t n,
-                          const std::size_t align ) : 
-            RingBufferBase< T, type >(),
-            term( false )
-   {
-      (this)->datamanager.set( new Buffer::Data<T, 
-                                      Type::Heap >( n, align ) );
+    RingBufferBaseMonitor(const std::size_t n, const std::size_t align)
+        : RingBufferBase<T, type>(), term(false)
+    {
+        (this)->datamanager.set(new Buffer::Data<T, Type::Heap>(n, align));
 
-      /** add monitor types immediately after construction **/
-      //sample_master.registerSample( new MeanSampleType< T, type >() );
-      //sample_master.registerSample( new ArrivalRateSampleType< T, type >() );
-      //sample_master.registerSample( new DepartureRateSampleType< T, type > () );
-      //(this)->monitor = new std::thread( Sample< T, type >::run, 
-      //                                   std::ref( *(this)      /** buffer **/ ),
-      //                                   std::ref( (this)->term /** term bool **/ ),
-      //                                   std::ref( (this)->sample_master ) );
+        /** add monitor types immediately after construction **/
+        // sample_master.registerSample( new MeanSampleType< T, type >() );
+        // sample_master.registerSample( new ArrivalRateSampleType< T, type >()
+        // );
+        // sample_master.registerSample( new DepartureRateSampleType< T, type >
+        // () );
+        //(this)->monitor = new std::thread( Sample< T, type >::run,
+        //                                   std::ref( *(this)      /** buffer
+        //                                   **/ ),
+        //                                   std::ref( (this)->term /** term
+        //                                   bool **/ ),
+        //                                   std::ref( (this)->sample_master )
+        //                                   );
+    }
 
-   }
+    void monitor_off()
+    {
+        (this)->term = true;
+    }
 
-   void  monitor_off()
-   {
-      (this)->term = true;
-   }
+    virtual ~RingBufferBaseMonitor()
+    {
+        (this)->term = true;
+        // monitor->join();
+        // delete( monitor );
+        // monitor = nullptr;
+        delete((this)->datamanager.get());
+    }
 
-   virtual ~RingBufferBaseMonitor()
-   {
-      (this)->term = true;
-      //monitor->join();
-      //delete( monitor );
-      //monitor = nullptr;
-      delete( (this)->datamanager.get() );
-   }
+    std::ostream& printQueueData(std::ostream& stream)
+    {
+        // stream << sample_master.printAllData( '\n' );
+        return (stream);
+    }
 
-   std::ostream&
-   printQueueData( std::ostream &stream )
-   {
-      //stream << sample_master.printAllData( '\n' );
-      return( stream );
-   }
+    virtual void resize(const std::size_t size, const std::size_t align,
+        volatile bool& exit_alloc)
+    {
+        if((this)->datamanager.is_resizeable())
+        {
+            (this)->datamanager.resize(
+                new Buffer::Data<T, type>(size, align), exit_alloc);
+        }
+        /** else, not resizeable..just return **/
+        return;
+    }
 
-   virtual void resize( const std::size_t size,
-                        const std::size_t align,
-                        volatile bool &exit_alloc )
-   {
-      if( (this)->datamanager.is_resizeable() )
-      {
-         (this)->datamanager.resize( 
-            new Buffer::Data< T, type >( size, align ), exit_alloc );
-      }
-      /** else, not resizeable..just return **/
-      return;
-   }
-   
-   virtual float get_frac_write_blocked()
-   {
-      const auto copy( (this)->write_stats );
-      (this)->write_stats.all = 0;
-      if( copy.blocked == 0 || copy.count == 0 )
-      {
-         return( 0.0 );
-      }
-      return( (float) copy.blocked / (float) copy.count );
-   }
+    virtual float get_frac_write_blocked()
+    {
+        const auto copy((this)->write_stats);
+        (this)->write_stats.all = 0;
+        if(copy.bec.blocked == 0 || copy.bec.count == 0)
+        {
+            return (0.0);
+        }
+        return ((float)copy.bec.blocked / (float)copy.bec.count);
+    }
+
 protected:
-   //std::thread       *monitor;
-   volatile bool      term;
-   //Sample< T, type >  sample_master;
+    // std::thread       *monitor;
+    volatile bool term;
+    // Sample< T, type >  sample_master;
 };
 
-template< class T > class RingBuffer< T, 
-                                      Type::Heap,
-                                      true /* monitor */ > :
-      public RingBufferBaseMonitor< T, Type::Heap >
+template <class T>
+class RingBuffer<T, Type::Heap, true /* monitor */>
+    : public RingBufferBaseMonitor<T, Type::Heap>
 {
 public:
-   /**
-    * RingBuffer - default constructor, initializes basic
-    * data structures.
-    */
-   RingBuffer( const std::size_t n, 
-               const std::size_t align = 16) : 
-                  RingBufferBaseMonitor< T, Type::Heap >( n, align)
-   {
-      /** nothing really to do **/
-   }
-   
-   virtual ~RingBuffer() = default;
-   
-   static FIFO* make_new_fifo( std::size_t n_items,
-                               std::size_t align,
-                               void *data )
-   {
-      assert( data == nullptr );
-      return( new RingBuffer< T, Type::Heap, true >( n_items, align ) ); 
-   }
+    /**
+     * RingBuffer - default constructor, initializes basic
+     * data structures.
+     */
+    RingBuffer(const std::size_t n, const std::size_t align = 16)
+        : RingBufferBaseMonitor<T, Type::Heap>(n, align)
+    {
+        /** nothing really to do **/
+    }
+
+    virtual ~RingBuffer() = default;
+
+    static FIFO* make_new_fifo(
+        std::size_t n_items, std::size_t align, void* data)
+    {
+        assert(data == nullptr);
+        return (new RingBuffer<T, Type::Heap, true>(n_items, align));
+    }
 };
 
 /** specialization for dummy one **/
-template< class T > class RingBuffer< T, 
-                                      Type::Infinite,
-                                      true /* monitor */ > :
-      public RingBufferBaseMonitor< T, Type::Infinite >
+template <class T>
+class RingBuffer<T, Type::Infinite, true /* monitor */>
+    : public RingBufferBaseMonitor<T, Type::Infinite>
 {
 public:
-   /**
-    * RingBuffer - default constructor, initializes basic
-    * data structures.
-    */
-   RingBuffer( const std::size_t n, const std::size_t align = 16 ) : 
-      RingBufferBaseMonitor< T, Type::Infinite >( 1, align )
-   {
-   }
-   virtual ~RingBuffer() = default;
+    /**
+     * RingBuffer - default constructor, initializes basic
+     * data structures.
+     */
+    RingBuffer(const std::size_t n, const std::size_t align = 16)
+        : RingBufferBaseMonitor<T, Type::Infinite>(1, align)
+    {
+    }
+    virtual ~RingBuffer() = default;
 
-   static FIFO* make_new_fifo( std::size_t n_items,
-                               std::size_t align,
-                               void *data )
-   {
-      assert( data == nullptr );
-      return( new RingBuffer< T, Type::Infinite, true >( n_items, align ) ); 
-   }
+    static FIFO* make_new_fifo(
+        std::size_t n_items, std::size_t align, void* data)
+    {
+        assert(data == nullptr);
+        return (new RingBuffer<T, Type::Infinite, true>(n_items, align));
+    }
 };
 
 /** specialization for dummy with no instrumentation **/
-template < class T > class RingBuffer < T,
-                                        Type::Infinite,
-                                        false > : 
-               public RingBufferBase< T, Type::Infinite >
+template <class T>
+class RingBuffer<T, Type::Infinite, false>
+    : public RingBufferBase<T, Type::Infinite>
 {
 public:
-   /**
-    * RingBuffer - default constructor, initializes basic
-    * data structures.
-    */
-   RingBuffer( const std::size_t n, const std::size_t align = 16 ) : 
-      RingBufferBase< T, Type::Infinite >()
-   {
-      (this)->datamanager.set( new Buffer::Data<T, Type::Heap >( 1, 16 ) );
-   }
+    /**
+     * RingBuffer - default constructor, initializes basic
+     * data structures.
+     */
+    RingBuffer(const std::size_t n, const std::size_t align = 16)
+        : RingBufferBase<T, Type::Infinite>()
+    {
+        (this)->datamanager.set(new Buffer::Data<T, Type::Heap>(1, 16));
+    }
 
-   virtual ~RingBuffer()
-   {
-      delete( (this)->datamanager.get() );
-   }
+    virtual ~RingBuffer()
+    {
+        delete((this)->datamanager.get());
+    }
 
-   /**
-    * make_new_fifo - builder function to dynamically
-    * allocate FIFO's at the time of execution.  The
-    * first two parameters are self explanatory.  The
-    * data ptr is a data struct that is dependent on the
-    * type of FIFO being built.  In there really is no
-    * data necessary so it is expacted to be set to nullptr
-    * @param   n_items - std::size_t
-    * @param   align   - memory alignment
-    * @return  FIFO*
-    */
-   static FIFO* make_new_fifo( std::size_t n_items,
-                               std::size_t align,
-                               void *data )
-   {
-      assert( data == nullptr );
-      return( new RingBuffer< T, Type::Infinite, false >( n_items, align ) ); 
-   }
-   
-   virtual void resize( const std::size_t size,
-                        const std::size_t align,
-                        bool  &exit_alloc )
-   {
-      assert( false );
-      /** TODO, implement me **/
-   }
-   
-   virtual float get_frac_write_blocked()
-   {
-      /** TODO, implement me **/
-      assert( false );
-   }
+    /**
+     * make_new_fifo - builder function to dynamically
+     * allocate FIFO's at the time of execution.  The
+     * first two parameters are self explanatory.  The
+     * data ptr is a data struct that is dependent on the
+     * type of FIFO being built.  In there really is no
+     * data necessary so it is expacted to be set to nullptr
+     * @param   n_items - std::size_t
+     * @param   align   - memory alignment
+     * @return  FIFO*
+     */
+    static FIFO* make_new_fifo(
+        std::size_t n_items, std::size_t align, void* data)
+    {
+        assert(data == nullptr);
+        return (new RingBuffer<T, Type::Infinite, false>(n_items, align));
+    }
 
+    virtual void resize(
+        const std::size_t size, const std::size_t align, bool& exit_alloc)
+    {
+        assert(false);
+        /** TODO, implement me **/
+    }
+
+    virtual float get_frac_write_blocked()
+    {
+        /** TODO, implement me **/
+        assert(false);
+    }
 };
 
 #if BUILDSHM
-/** 
- * SharedMemory 
+/**
+ * SharedMemory
  */
-template< class T > class RingBuffer< T, 
-                                      Type::SharedMemory, 
-                                      false > :
-                            public RingBufferBase< T, Type::SharedMemory >
+template <class T>
+class RingBuffer<T, Type::SharedMemory, false>
+    : public RingBufferBase<T, Type::SharedMemory>
 {
 public:
-   RingBuffer( const std::size_t      nitems,
-               const std::string key,
-               Direction         dir,
-               const std::size_t      alignment = 16 ) : 
-               RingBufferBase< T, Type::SharedMemory >(),
-                                              shm_key( key )
-   {
-      (this)->datamanager.set( 
-         new Buffer::Data< T, 
-                           Type::SharedMemory >( nitems, key, dir, alignment ) );
-   }
+    RingBuffer(const std::size_t nitems, const std::string key, Direction dir,
+        const std::size_t alignment = 16)
+        : RingBufferBase<T, Type::SharedMemory>(), shm_key(key)
+    {
+        (this)->datamanager.set(new Buffer::Data<T, Type::SharedMemory>(
+            nitems, key, dir, alignment));
+    }
 
-   virtual ~RingBuffer()
-   {
-      delete( (this)->datamanager.get() );      
-   }
-  
-   struct Data
-   {
-      const std::string key;
-      Direction   dir;
-   };
+    virtual ~RingBuffer()
+    {
+        delete((this)->datamanager.get());
+    }
 
-   /**
-    * make_new_fifo - builder function to dynamically
-    * allocate FIFO's at the time of execution.  The
-    * first two parameters are self explanatory.  The
-    * data ptr is a data struct that is dependent on the
-    * type of FIFO being built.  In there really is no
-    * data necessary so it is expacted to be set to nullptr
-    * @param   n_items - std::size_t
-    * @param   align   - memory alignment
-    * @return  FIFO*
-    */
-   static FIFO* make_new_fifo( std::size_t n_items,
-                               std::size_t align,
-                               void *data )
-   {
-      auto *data_ptr( reinterpret_cast< Data* >( data ) );
-      return( new RingBuffer< T, Type::SharedMemory, false >( n_items, 
-                                                              data_ptr->key,
-                                                              data_ptr->dir,
-                                                              align ) ); 
-   }
-   
-   virtual void resize( const std::size_t size,
-                        const std::size_t align,
-                        volatile bool &exit_alloc )
-   {
-      assert( false );
-      /** TODO, implement me **/
-   }
+    struct Data
+    {
+        const std::string key;
+        Direction dir;
+    };
 
-   virtual float get_frac_write_blocked()
-   {
-      assert( false );
-      return( 0.0 );
-   }
+    /**
+     * make_new_fifo - builder function to dynamically
+     * allocate FIFO's at the time of execution.  The
+     * first two parameters are self explanatory.  The
+     * data ptr is a data struct that is dependent on the
+     * type of FIFO being built.  In there really is no
+     * data necessary so it is expacted to be set to nullptr
+     * @param   n_items - std::size_t
+     * @param   align   - memory alignment
+     * @return  FIFO*
+     */
+    static FIFO* make_new_fifo(
+        std::size_t n_items, std::size_t align, void* data)
+    {
+        auto* data_ptr(reinterpret_cast<Data*>(data));
+        return (new RingBuffer<T, Type::SharedMemory, false>(
+            n_items, data_ptr->key, data_ptr->dir, align));
+    }
+
+    virtual void resize(const std::size_t size, const std::size_t align,
+        volatile bool& exit_alloc)
+    {
+        assert(false);
+        /** TODO, implement me **/
+    }
+
+    virtual float get_frac_write_blocked()
+    {
+        assert(false);
+        return (0.0);
+    }
 
 protected:
-   const  std::string shm_key;
+    const std::string shm_key;
 };
 
 
 /**
  * TCP w/ multiplexing
  */
-template <class T> class RingBuffer< T,
-                                     Type::TCP,
-                                     false /* no monitoring yet */ > :
-                                       public RingBufferBase< T, Type::Heap >
+template <class T>
+class RingBuffer<T, Type::TCP, false /* no monitoring yet */>
+    : public RingBufferBase<T, Type::Heap>
 {
 public:
-   RingBuffer( const std::size_t      nitems,
-               const std::string dns_name,
-               Direction         dir,
-               const std::size_t      alignment = 16 ) : 
-                  RingBufferBase< T, 
-                                  Type::Heap >()
-   {
-      //TODO, fill in stuff here
-   }
+    RingBuffer(const std::size_t nitems, const std::string dns_name,
+        Direction dir, const std::size_t alignment = 16)
+        : RingBufferBase<T, Type::Heap>()
+    {
+        // TODO, fill in stuff here
+    }
 
-   virtual ~RingBuffer() = default;
-   
-   struct Data
-   {
-      Direction   dir;
-      std::string dns_name;
-   };
+    virtual ~RingBuffer() = default;
 
-   static FIFO* make_new_fifo( const std::size_t n,
-                               const std::size_t align,
-                               void *data )
-   {
-      auto *cast_data( 
-         reinterpret_cast< RingBuffer< T, Type::TCP, false >::Data* >( data ) );
+    struct Data
+    {
+        Direction dir;
+        std::string dns_name;
+    };
 
-      return( new RingBuffer< T, Type::TCP, false >(n /** n_items **/,
-                                                    cast_data->dns_name,
-                                                    cast_data->dir,
-                                                    align ) );
-   }
-   
-   virtual void resize( const std::size_t size,
-                        const std::size_t align,
-                        volatile bool &exit_alloc )
-   {
-      assert( false );
-      /** TODO implement me **/
-   }
-   
-   virtual float get_frac_write_blocked()
-   {
-      assert( false );
-      return( 0.0 );
-   }
+    static FIFO* make_new_fifo(
+        const std::size_t n, const std::size_t align, void* data)
+    {
+        auto* cast_data(
+            reinterpret_cast<RingBuffer<T, Type::TCP, false>::Data*>(data));
+
+        return (new RingBuffer<T, Type::TCP, false>(
+            n /** n_items **/, cast_data->dns_name, cast_data->dir, align));
+    }
+
+    virtual void resize(const std::size_t size, const std::size_t align,
+        volatile bool& exit_alloc)
+    {
+        assert(false);
+        /** TODO implement me **/
+    }
+
+    virtual float get_frac_write_blocked()
+    {
+        assert(false);
+        return (0.0);
+    }
+
 protected:
 };
-#endif //end BUILDSHM
+#endif // end BUILDSHM
 #endif /* END _RINGBUFFER_TCC_ */

--- a/raftinc/ringbufferbase.tcc
+++ b/raftinc/ringbufferbase.tcc
@@ -1,10 +1,10 @@
 /**
- * ringbufferbase.tcc - 
+ * ringbufferbase.tcc -
  * @author: Jonathan Beard
  * @version: Thu May 15 09:06:52 2014
- * 
+ *
  * Copyright 2014 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -58,7 +58,7 @@ class RingBufferBase
 {
 public:
     RingBufferBase() = delete;
-    virtual ~RingBufferBase() = delete;;
+    virtual ~RingBufferBase() = delete;
 };
 
 

--- a/raftinc/split.tcc
+++ b/raftinc/split.tcc
@@ -1,10 +1,10 @@
 /**
- * split.tcc - 
+ * split.tcc -
  * @author: Jonathan Beard
  * @version: Mon Oct 20 09:49:17 2014
- * 
+ *
  * Copyright 2014 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -29,7 +29,9 @@ public:
    split( const std::size_t num_ports = 1 ) : parallel_k()
    {
       input.addPort< T >( "0" );
-      for( auto it( 0 ); it < num_ports; it++ )
+
+      using index_type = std::remove_const_t<decltype(num_ports)>;
+      for( index_type it( 0 ); it < num_ports; it++ )
       {
          addPort();
       }
@@ -54,7 +56,7 @@ public:
       }
       return( raft::proceed );
    }
-   
+
    virtual std::size_t  addPort()
    {
       return( (this)->addPortTo< T >( output ) );
@@ -63,12 +65,12 @@ public:
 protected:
    virtual void lock()
    {
-      lock_helper( input ); 
+      lock_helper( input );
    }
-   
+
    virtual void unlock()
    {
-      unlock_helper( input ); 
+      unlock_helper( input );
    }
    method split_func;
 };

--- a/raftinc/splitmethod.hpp
+++ b/raftinc/splitmethod.hpp
@@ -1,10 +1,10 @@
 /**
- * splitmethod.hpp - 
+ * splitmethod.hpp -
  * @author: Jonathan Beard
  * @version: Tue Oct 28 12:56:43 2014
- * 
+ *
  * Copyright 2014 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -32,14 +32,14 @@
 class autoreleasebase;
 
 /** FIXME, it's relativly easy to do zero copy....so implement **/
-class splitmethod 
+class splitmethod
 {
 public:
    splitmethod()          = default;
    virtual ~splitmethod() = default;
-   
-   template < class T /* item */, 
-              typename std::enable_if<    
+
+   template < class T /* item */,
+              typename std::enable_if<
                         std::is_fundamental< T >::value >::type* = nullptr >
       bool send( T &item, const raft::signal signal, Port &outputs )
    {
@@ -52,7 +52,7 @@ public:
       else
       {
          return( false );
-      }  
+      }
    }
 
    /**
@@ -61,29 +61,31 @@ public:
     * only on the autorelease object shortly, but for now this will
     * get it working.
     * @param   range - T&, autorelease object
-    * @param   outputs - output port list 
+    * @param   outputs - output port list
     */
-   template < class T   /* peek range obj,  */, 
-              typename std::enable_if<    
-                       not std::is_base_of< autoreleasebase, 
+   template < class T   /* peek range obj,  */,
+              typename std::enable_if<
+                       not std::is_base_of< autoreleasebase,
                                         T >::value >::type* = nullptr >
       bool send( T &range, Port &outputs )
    {
       auto * const fifo( select_fifo( outputs, sendtype ) );
       if( fifo != nullptr )
       {
-         const auto space_avail( 
+         const auto space_avail(
             std::min( fifo->space_avail(), range.size() ) );
-         for( auto i( 0 ); i < space_avail; i++ )
+
+         using index_type = std::remove_const_t<decltype(space_avail)>;
+         for( index_type i( 0 ); i < space_avail; i++ )
          {
-            fifo->push( range[ i ].ele, range[ i ].sig ); 
+            fifo->push( range[ i ].ele, range[ i ].sig );
          }
          return( true );
       }
       else
       {
          return( false );
-      }  
+      }
    }
 
    template < class T /* item */ >

--- a/raftinc/writeeach.tcc
+++ b/raftinc/writeeach.tcc
@@ -1,10 +1,10 @@
 /**
- * write_each.tcc - 
+ * write_each.tcc -
  * @author: Jonathan Beard
  * @version: Sun Oct 26 15:51:46 2014
- * 
+ *
  * Copyright 2014 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -58,7 +58,9 @@ public:
             if( avail_data != 0 )
             {
                 auto alldata( port.template peek_range< T >( avail_data ) );
-                for( auto index( 0 ); index < avail_data; index++ )
+
+                using index_type = std::remove_const_t<decltype(avail_data)>;
+                for( index_type index( 0 ); index < avail_data; index++ )
                 {
                    (*inserter) = alldata[ index ].ele;
                    /** hope the iterator defined overloaded ++ **/
@@ -74,7 +76,7 @@ private:
 };
 
 template < class T, class BackInsert >
-static 
+static
 writeeach< T, BackInsert >
 write_each( BackInsert &&bi )
 {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,5 +26,10 @@ target_link_libraries( raft
                        ${CMAKE_SCOTCH_LIBS}
                        m )
 
+
+target_compile_options( raft
+                        PUBLIC
+                        "-W" "-Wall" "-Wextra" "-Wpedantic" )
+
 install( TARGETS raft
          ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,7 @@ if ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"
 
 target_compile_options( raft
                         PUBLIC
-                        "-W" "-Wall" "-Wextra" "-Wpedantic" )
+                        "-W" "-Wall" "-Wextra" "-Wpedantic" "-Wno-unused-parameter" )
 
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,9 +27,15 @@ target_link_libraries( raft
                        m )
 
 
+# Enable warnings if using clang or gcc.
+if ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" 
+  OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" )
+
 target_compile_options( raft
                         PUBLIC
                         "-W" "-Wall" "-Wextra" "-Wpedantic" )
+
+endif()
 
 install( TARGETS raft
          ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib )

--- a/src/allocate.cpp
+++ b/src/allocate.cpp
@@ -1,10 +1,10 @@
 /**
- * allocate.cpp - 
+ * allocate.cpp -
  * @author: Jonathan Beard
  * @version: Tue Sep 16 20:20:06 2014
- * 
+ *
  * Copyright 2014 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -27,7 +27,7 @@
 #include "map.hpp"
 #include "portexception.hpp"
 
-Allocate::Allocate( raft::map &map, volatile bool &exit_alloc ) : 
+Allocate::Allocate( raft::map &map, volatile bool &exit_alloc ) :
    source_kernels( map.source_kernels ),
    all_kernels(    map.all_kernels ),
    exit_alloc( exit_alloc )
@@ -43,20 +43,20 @@ Allocate::~Allocate()
 }
 
 void
-Allocate::waitTillReady() 
+Allocate::waitTillReady()
 {
    while( ! ready );
 }
 
 void
-Allocate::setReady() 
+Allocate::setReady()
 {
    ready = true;
 }
 
 void
-Allocate::initialize( PortInfo * const src, 
-                      PortInfo * const dst, 
+Allocate::initialize( PortInfo * const src,
+                      PortInfo * const dst,
                       FIFO * const fifo )
 {
    assert( fifo != nullptr );
@@ -64,12 +64,12 @@ Allocate::initialize( PortInfo * const src,
    assert( src  != nullptr );
    if( src->getFIFO() != nullptr )
    {
-      throw PortDoubleInitializeException( 
+      throw PortDoubleInitializeException(
          "Source port \"" + src->my_name + "\" already initialized!" );
    }
    if( dst->getFIFO() !=  nullptr )
    {
-      throw PortDoubleInitializeException( 
+      throw PortDoubleInitializeException(
          "Destination port \"" + dst->my_name +  "\" already initialized!" );
    }
    src->setFIFO( fifo );
@@ -77,27 +77,29 @@ Allocate::initialize( PortInfo * const src,
    dst->setFIFO( fifo );
    fifo->set_dst_kernel( dst->my_kernel );
    /** NOTE: this list simply speeds up the monitoring if we want it **/
-   allocated_fifo.insert( fifo ); 
+   allocated_fifo.insert( fifo );
 }
 
 
-void 
+void
 Allocate::allocate( PortInfo &a, PortInfo &b, void *data )
 {
+   (void) data;
+
    FIFO *fifo( nullptr );
    instr_map_t * const func_map( a.const_map[ Type::Heap ] );
    auto test_func( (*func_map)[ false ] );
-   
+
    if( a.existing_buffer != nullptr )
    {
-      fifo = test_func( a.nitems, 
+      fifo = test_func( a.nitems,
                         a.start_index,
                         a.existing_buffer );
    }
    else
    {
-      fifo = test_func( INITIAL_ALLOC_SIZE    /* items */, 
-                        ALLOC_ALIGN_WIDTH     /* align */, 
+      fifo = test_func( INITIAL_ALLOC_SIZE    /* items */,
+                        ALLOC_ALIGN_WIDTH     /* align */,
                         nullptr );
    }
    initialize( &a, &b, fifo );

--- a/src/fifo.cpp
+++ b/src/fifo.cpp
@@ -1,10 +1,10 @@
 /**
- * FIFO.cpp - 
+ * FIFO.cpp -
  * @author: Jonathan Beard
  * @version: Thu Sep  4 12:59:45 2014
- * 
+ *
  * Copyright 2014 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -32,6 +32,7 @@ void
 FIFO::get_zero_read_stats( Blocked &copy )
 {
    /** default version does nothing at all **/
+   (void) copy;
    return;
 }
 
@@ -39,6 +40,7 @@ void
 FIFO::get_zero_write_stats( Blocked &copy )
 {
    /** default version does nothing at all **/
+   (void) copy;
    return;
 }
 

--- a/src/graphtools.cpp
+++ b/src/graphtools.cpp
@@ -1,10 +1,10 @@
 /**
- * graphtools.cpp - 
+ * graphtools.cpp -
  * @author: Jonathan Beard
  * @version: Sat Sep 20 13:15:09 2014
- * 
+ *
  * Copyright 2014 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -43,7 +43,7 @@ GraphTools::BFS( std::set< raft::kernel* > &source_kernels,
    std::for_each( source_kernels.begin(),
                   source_kernels.end(),
                   [&]( raft::kernel *k )
-                  { 
+                  {
                      queue.push( k );
                      visited_set.insert( k );
                   } );
@@ -61,7 +61,7 @@ GraphTools::BFS( std::vector< raft::kernel* > &source_kernels,
    std::for_each( source_kernels.begin(),
                   source_kernels.end(),
                   [&]( raft::kernel *k )
-                  { 
+                  {
                      queue.push( k );
                      visited_set.insert( k );
                   } );
@@ -84,12 +84,12 @@ GraphTools::BFS( std::set< raft::kernel* > &source_kernels,
                      visited_set.insert( k );
                   });
 
-   GraphTools::__BFS( queue, visited_set, func, data ); 
+   GraphTools::__BFS( queue, visited_set, func, data );
    return;
 }
-                    
 
-void 
+
+void
 GraphTools::__BFS( std::queue< raft::kernel* > &queue,
                    std::set<   raft::kernel* > &visited_set,
                    edge_func                   func,
@@ -116,7 +116,7 @@ GraphTools::__BFS( std::queue< raft::kernel* > &queue,
          /** get dst edge to call function on **/
          if( source.other_kernel != nullptr  )
          {
-            PortInfo &dst( 
+            PortInfo &dst(
                source.other_kernel->input.getPortInfoFor( source.other_name ) );
             func( source, dst, data );
          }
@@ -124,8 +124,8 @@ GraphTools::__BFS( std::queue< raft::kernel* > &queue,
          if( connected_error )
          {
             std::stringstream ss;
-            ss << "Unconnected port detected at " << 
-               common::printClassName( *k ) <<  
+            ss << "Unconnected port detected at " <<
+               common::printClassName( *k ) <<
                   "[ \"" <<
                   source.my_name << " \"], please fix and recompile.";
             k->output.portmap.mutex_map.unlock();
@@ -135,7 +135,7 @@ GraphTools::__BFS( std::queue< raft::kernel* > &queue,
          if( visited_set.find( source.other_kernel ) == visited_set.end() )
          {
             queue.push( source.other_kernel );
-            visited_set.insert( source.other_kernel ); 
+            visited_set.insert( source.other_kernel );
          }
       }
       k->output.portmap.mutex_map.unlock();
@@ -175,7 +175,7 @@ GraphTools::__BFS( std::queue< raft::kernel* > &queue,
             if( visited_set.find( source.other_kernel ) == visited_set.end() )
             {
                queue.push( source.other_kernel );
-               visited_set.insert( source.other_kernel ); 
+               visited_set.insert( source.other_kernel );
             }
          }
       }
@@ -190,6 +190,11 @@ GraphTools::__DFS( std::stack< raft::kernel* > &stack,
                    edge_func                   func,
                    void                        *data )
 {
+   (void) stack;
+   (void) visited_set;
+   (void) func;
+   (void) data;
+
    /** TODO, implement me **/
    assert( false );
 }
@@ -200,6 +205,11 @@ GraphTools::__DFS( std::stack< raft::kernel* > &stack,
                    vertex_func                 func,
                    void                        *data )
 {
+   (void) stack;
+   (void) visited_set;
+   (void) func;
+   (void) data;
+
    /** TODO, implement me **/
    assert( false );
 }

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -10,11 +10,11 @@ std::size_t kernel::kernel_count( 0 );
 kernel::kernel() : kernel_id( kernel::kernel_count )
 {
    kernel::kernel_count++;
-};
+}
 
 /** existing memory **/
-kernel::kernel( void * const ptr, 
-                const std::size_t nbytes ) : 
+kernel::kernel( void * const ptr,
+                const std::size_t nbytes ) :
    input(  this, ptr, nbytes ),
    output( this, ptr, nbytes ),
    kernel_id( kernel::kernel_count )
@@ -28,7 +28,7 @@ kernel::get_id()
    return( kernel_id );
 }
 
-raft::kernel& 
+raft::kernel&
 kernel::operator []( const std::string &&portname )
 {
    if( enabled_port.size() < 2 )
@@ -49,15 +49,15 @@ kernel::addPort()
 {
    return( 0 );
 }
-   
-void 
+
+void
 kernel::lock()
 {
    /** does nothing, just need a base impl **/
    return;
 }
 
-void 
+void
 kernel::unlock()
 {
    /** does nothing, just need a base impl **/
@@ -80,7 +80,7 @@ kernel::getEnabledPort()
 //kernel::getName()
 //{
 //   int status( 0 );
-//   const std::string name_a( 
+//   const std::string name_a(
 //      abi::__cxa_demangle( typeid( *(this) ).name(), 0, 0, &status ) );
 //
 //}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1,10 +1,10 @@
 /**
- * map.cpp - 
+ * map.cpp -
  * @author: Jonathan Beard
  * @version: Fri Sep 12 10:28:33 2014
- * 
+ *
  * Copyright 2014 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -38,7 +38,7 @@
 
 raft::map::map() : MapBase()
 {
-  
+
 }
 
 void
@@ -51,8 +51,14 @@ raft::map::checkEdges( kernelkeeper &source_k )
     * a user will have to fix.  Otherwise will return with no
     * errors.
     */
-   GraphTools::BFS( container, 
-                    []( PortInfo &a, PortInfo &b, void *data ){ return; },
+   GraphTools::BFS( container,
+                    []( PortInfo &a, PortInfo &b, void *data )
+                    {
+                       (void) a;
+                       (void) b;
+                       (void) data;
+                       return;
+                    },
                     nullptr,
                     true );
    source_k.release();
@@ -60,30 +66,30 @@ raft::map::checkEdges( kernelkeeper &source_k )
 }
 
 /**
-   void insert( raft::kernel &a,  PortInfo &a_out, 
+   void insert( raft::kernel &a,  PortInfo &a_out,
                 raft::kernel &b,  PortInfo &b_in,
                 raft::kernel &i,  PortInfo &i_in, PortInfo &i_out );
 **/
-void 
+void
 raft::map::enableDuplication( kernelkeeper &source, kernelkeeper &all )
 {
     auto &source_k( source.acquire() );
     auto &all_k   ( all.acquire()    );
     /** don't have to do this but it makes it far more apparent where it comes from **/
     void * const kernel_ptr( reinterpret_cast< void* >( &all_k ) );
-    using kernel_ptr_t = 
+    using kernel_ptr_t =
       typename std::remove_reference< decltype( all_k ) >::type;
     /** need to grab impl of Lengauer and Tarjan dominators, use for SESE **/
     /** in the interim, restrict to kernels that are simple to duplicate **/
     GraphTools::BFS( source_k,
                      []( PortInfo &a, PortInfo &b, void *data )
                      {
-                        auto * const all_k( reinterpret_cast< kernel_ptr_t* >( data ) );  
+                        auto * const all_k( reinterpret_cast< kernel_ptr_t* >( data ) );
                         if( a.out_of_order && b.out_of_order )
                         {
                            /** case of inline kernel **/
-                           if( b.my_kernel->input.count() == 1 && 
-                               b.my_kernel->output.count() == 1 && 
+                           if( b.my_kernel->input.count() == 1 &&
+                               b.my_kernel->output.count() == 1 &&
                                a.my_kernel->dup_candidate  )
                            {
                               auto *kernel_a( a.my_kernel );
@@ -93,10 +99,10 @@ raft::map::enableDuplication( kernelkeeper &source, kernelkeeper &all )
                               auto &front_port_info( front->output.getPortInfo() );
                               /**
                                * front -> kernel_a goes to
-                               * front -> split -> kernel_a 
+                               * front -> split -> kernel_a
                                */
-                              auto *split( 
-                                 static_cast< raft::kernel* >( 
+                              auto *split(
+                                 static_cast< raft::kernel* >(
                                     port_info_front.split_func() ) );
                               all_k->insert( split );
                               MapBase::insert( front,    front_port_info,
@@ -105,26 +111,26 @@ raft::map::enableDuplication( kernelkeeper &source, kernelkeeper &all )
 
                               assert( kernel_a->output.count() == 1 );
 
-                              /** 
-                               * now we need the port info from the input 
-                               * port on back 
+                              /**
+                               * now we need the port info from the input
+                               * port on back
                                **/
 
                               /**
                                * kernel_a -> back goes to
-                               * kernel_a -> join -> back 
+                               * kernel_a -> join -> back
                                */
                               auto *join( static_cast< raft::kernel* >( a.join_func() ) );
                               all_k->insert( join );
                               MapBase::insert( a.my_kernel, a,
                                                b.my_kernel, b,
                                                join );
-                              /** 
+                              /**
                                * finally set the flag to the scheduler
                                * so that the parallel map manager can
                                * pick it up an use it.
                                */
-                              a.my_kernel->dup_enabled = true; 
+                              a.my_kernel->dup_enabled = true;
                            }
                            /** parallalizable source, single output no inputs**/
                            else if( a.my_kernel->input.count() == 0 &&
@@ -135,13 +141,13 @@ raft::map::enableDuplication( kernelkeeper &source, kernelkeeper &all )
                               MapBase::insert( a.my_kernel, a,
                                                b.my_kernel, b,
                                                join );
-                              a.my_kernel->dup_enabled = true; 
+                              a.my_kernel->dup_enabled = true;
                            }
                            /** parallelizable sink, single input, no outputs **/
                            else if( b.my_kernel->input.count() == 1 &&
                                     b.my_kernel->output.count() == 0 )
                            {
-                              auto *split( 
+                              auto *split(
                                  static_cast< raft::kernel* >( b.split_func() ) );
                               all_k->insert( split );
                               MapBase::insert( a.my_kernel, a,
@@ -149,7 +155,7 @@ raft::map::enableDuplication( kernelkeeper &source, kernelkeeper &all )
                                                split );
                               b.my_kernel->dup_enabled = true;
                            }
-                           /** 
+                           /**
                             * flag as candidate if the connecting
                             * kernel only has one input port.
                             */
@@ -158,7 +164,7 @@ raft::map::enableDuplication( kernelkeeper &source, kernelkeeper &all )
                               /** simply flag as a candidate **/
                               b.my_kernel->dup_candidate = true;
                            }
-                              
+
                         }
                      },
                      kernel_ptr,
@@ -167,7 +173,7 @@ raft::map::enableDuplication( kernelkeeper &source, kernelkeeper &all )
    all.release();
 }
 
-void 
+void
 raft::map::joink( kpair * const next )
 {
         /** might be able to do better by re-doing with templates **/
@@ -175,16 +181,16 @@ raft::map::joink( kpair * const next )
         {
             if( next->out_of_order )
             {
-                (this)->link< raft::order::out >( next->src, 
+                (this)->link< raft::order::out >( next->src,
                                                   next->src_name,
-                                                  next->dst, 
+                                                  next->dst,
                                                   next->dst_name );
             }
             else
             {
-                (this)->link( next->src, 
+                (this)->link( next->src,
                               next->src_name,
-                              next->dst, 
+                              next->dst,
                               next->dst_name );
 
             }
@@ -193,14 +199,14 @@ raft::map::joink( kpair * const next )
         {
             if( next->out_of_order )
             {
-                (this)->link< raft::order::out >( next->src, 
-                                                  next->src_name, 
+                (this)->link< raft::order::out >( next->src,
+                                                  next->src_name,
                                                   next->dst );
             }
             else
             {
-                (this)->link( next->src, 
-                              next->src_name, 
+                (this)->link( next->src,
+                              next->src_name,
                               next->dst );
             }
         }
@@ -208,14 +214,14 @@ raft::map::joink( kpair * const next )
         {
             if( next->out_of_order )
             {
-                (this)->link< raft::order::out >( next->src, 
-                                                  next->dst, 
+                (this)->link< raft::order::out >( next->src,
+                                                  next->dst,
                                                   next->dst_name );
             }
             else
             {
-                (this)->link( next->src, 
-                              next->dst, 
+                (this)->link( next->src,
+                              next->dst,
                               next->dst_name );
             }
         }
@@ -223,12 +229,12 @@ raft::map::joink( kpair * const next )
         {
             if( next->out_of_order )
             {
-                (this)->link< raft::order::out >( next->src, 
+                (this)->link< raft::order::out >( next->src,
                                                   next->dst );
             }
             else
             {
-                (this)->link( next->src, 
+                (this)->link( next->src,
                               next->dst );
             }
         }
@@ -241,17 +247,17 @@ raft::map::operator += ( kpair &p )
 {
     kpair * const pair = &p;
     assert( pair != nullptr );
-    raft::kernel *end( pair->dst ); 
+    raft::kernel *end( pair->dst );
     /** start at the head, go forward **/
     kpair *next = pair->head;
     assert( next != nullptr );
     raft::kernel *start( next->src );
-    
+
     /** used to do nested splits **/
     enum sj_t : int8_t { split, join, cont };
     const static std::array< std::string, 3 > sj_t_str = { "split", "join", "cont" };
-    
-    auto next_link_type( []( const kpair * const k ) -> sj_t 
+
+    auto next_link_type( []( const kpair * const k ) -> sj_t
     {
         if( k->split_to && ! k->join_from )
         {
@@ -273,7 +279,7 @@ raft::map::operator += ( kpair &p )
         assert( false );
         return( cont );
     });
-    
+
     std::stack< sj_t > stack;
     /**
      * dup kernels arranged in "groups" so that
@@ -287,19 +293,19 @@ raft::map::operator += ( kpair &p )
      */
     kernels_t  groups;
 
-    /** 
+    /**
      * keep # of out-edges for splits
      */
     split_stack_t split_out_edges;
 
     /** could throw an exception so use push_back **/
     groups.push_back( up_group_t( new group_t( ) ) );
-    /** 
-     * start kernels vector off 
+    /**
+     * start kernels vector off
      * emplace used since kernel can't throw an exception
      */
     groups.back()->emplace_back( next->src );
-    
+
     /** hold on to these for a bit so we can back track if needed **/
     std::vector< kpair* > kpair_store;
 
@@ -310,7 +316,7 @@ raft::map::operator += ( kpair &p )
         decltype( groups ) temp_groups;
         switch( stack.top() )
         {
-                
+
             case( cont ):
             {
                 inline_cont( groups,
@@ -356,38 +362,38 @@ raft::map::operator += ( kpair &p )
             default:
                 assert( false );
         }
-        
+
         groups.clear();
         groups = std::move( temp_groups );
-        
-        
+
+
         kpair *temp_kpair = next;
         next = next->next;
         kpair_store.emplace_back( temp_kpair );
     }
-    /** 
+    /**
      * we should be emptying each time, so this should
-     * always be zero or one at most 
+     * always be zero or one at most
      */
     assert( groups.size() < 2 );
     for( auto *ptr : kpair_store )
     {
         delete( ptr );
     }
-    /** 
-     * FIXME, re-write kernel_pair_t so it returns struct with 
+    /**
+     * FIXME, re-write kernel_pair_t so it returns struct with
      * iterators so that we can access an array of ends if the
      * run-time creates them.
      */
     return( kernel_pair_t( start, end ) );
 }
 
-void 
+void
 raft::map::inline_cont( kernels_t &groups,
                         kernels_t &temp_groups,
                         kpair * const next )
 {
-    /** 
+    /**
      * for each kernel, and each group make an output
      * link inline
      */
@@ -406,7 +412,7 @@ raft::map::inline_cont( kernels_t &groups,
                 temp_groups[ 0 ]->emplace_back( next->dst );
             }
             else
-            {   
+            {
                 auto * const dst_clone( next->dst->clone() );
                 next->src = kernel;
                 next->dst = dst_clone;
@@ -439,12 +445,12 @@ raft::map::inline_split( split_stack_t &split_stack,
             //only one port, user meant
             //to use raft::out likely not
             //the static split
-    
-            //TODO: throw exception for more 
+
+            //TODO: throw exception for more
             //than one input port for destination
             //won't work with split/join
             temp_groups.push_back( up_group_t( new group_t() ) );
-            //for each output port in kernel 
+            //for each output port in kernel
             if( temp_groups[ 0 ]->size() == 0 )
             {
                 auto &port( kernel->output );
@@ -522,12 +528,12 @@ raft::map::inline_join( split_stack_t &split_stack,
 
     for( auto &group : groups )
     {
-        /** 
+        /**
          * need to add exception for too many
-         * output ports for source, or too 
+         * output ports for source, or too
          * few input ports for destination
          */
-        
+
         if( count <= 0 )
         {
             temp_groups.push_back( up_group_t( new group_t() ) );
@@ -541,7 +547,7 @@ raft::map::inline_join( split_stack_t &split_stack,
              * take all kernels from first group, attach
              * to current dst. kernel
              */
-            joinfunc( group, next ); 
+            joinfunc( group, next );
         }
         else
         {
@@ -551,7 +557,7 @@ raft::map::inline_join( split_stack_t &split_stack,
             auto *temp_groups_k( next->dst->clone() );
             next->dst = temp_groups_k;
             temp_groups.back()->emplace_back( temp_groups_k );
-            joinfunc( group, next ); 
+            joinfunc( group, next );
         }
         count--;
     }
@@ -569,7 +575,11 @@ raft::map::inline_dup_join( kernels_t &groups,
     temp_groups.push_back( up_group_t( new group_t() ) );
     up_group_t &gp( groups[ 0 ] );
     const auto dest_in_count( next->dst_in_count );
-    for( auto port_it( next->dst->input.begin() ); 
+    (void) gp;
+    (void) dest_in_count;
+
+
+    for( auto port_it( next->dst->input.begin() );
         port_it != next->dst->input.end(); ++port_it )
     {
         if( port_it == next->dst->input.begin() )
@@ -579,8 +589,8 @@ raft::map::inline_dup_join( kernels_t &groups,
             next->has_dst_name = true;
             joink( next );
             temp_groups.back()->emplace_back( next->dst );
-            /** 
-             * at this point a single chain has been added 
+            /**
+             * at this point a single chain has been added
              * but we need to check for the next one to make
              * sure that we don't need to duplicate from head
              */
@@ -589,7 +599,7 @@ raft::map::inline_dup_join( kernels_t &groups,
         {
             /**
              * need to find out if there's more than one kernel in front
-             * of this one. don't need to keep track of the new kernels 
+             * of this one. don't need to keep track of the new kernels
              * here.
              */
             raft::kernel *src( nullptr );

--- a/src/noparallel.cpp
+++ b/src/noparallel.cpp
@@ -1,10 +1,10 @@
 /**
- * noparallel.cpp - 
+ * noparallel.cpp -
  * @author: Jonathan Beard
  * @version: Mon Aug 10 20:00:25 2015
- * 
+ *
  * Copyright 2015 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -23,11 +23,16 @@
 #include "streamingstat.tcc"
 #include <map>
 
-no_parallel::no_parallel(       raft::map &map, 
+no_parallel::no_parallel(       raft::map &map,
                                 Allocate &alloc,
                                 Schedule &sched,
                                 volatile bool &exit_para )
 {
+   (void) map;
+   (void) alloc;
+   (void) sched;
+   (void) exit_para;
+
    /** nothing to do here, move along **/
 }
 

--- a/src/partition_dummy.cpp
+++ b/src/partition_dummy.cpp
@@ -1,10 +1,10 @@
 /**
- * partition_dummy.cpp - 
+ * partition_dummy.cpp -
  * @author: Jonathan Beard
  * @version: Wed May  4 19:27:05 2016
- * 
+ *
  * Copyright 2016 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -19,8 +19,9 @@
  */
 #include "partition_dummy.hpp"
 
-void 
+void
 partition_dummy::partition( kernelkeeper &kernels )
 {
+    (void) kernels;
     return;
 }

--- a/src/schedule.cpp
+++ b/src/schedule.cpp
@@ -10,8 +10,8 @@ Schedule::Schedule( raft::map &map ) : kernel_set( map.all_kernels ),
                                  source_kernels( map.source_kernels ),
                                  dst_kernels( map.dst_kernels )
 {
-   //TODO, see if we want to keep this 
-   handlers.addHandler( raft::quit, Schedule::quitHandler ); 
+   //TODO, see if we want to keep this
+   handlers.addHandler( raft::quit, Schedule::quitHandler );
 }
 
 Schedule::~Schedule()
@@ -27,7 +27,7 @@ Schedule::init()
 
 
 raft::kstatus
-Schedule::quitHandler( FIFO              &fifo, 
+Schedule::quitHandler( FIFO              &fifo,
                        raft::kernel      *kernel,
                        const raft::signal signal,
                        void              *data )
@@ -37,24 +37,29 @@ Schedule::quitHandler( FIFO              &fifo,
     * currently, however that may change in the futre
     * with more features and systems added.
     */
-   fifo.invalidate();  
+
+   (void) kernel;
+   (void) signal;
+   (void) data;
+
+   fifo.invalidate();
    return( raft::stop );
 }
 
-void 
+void
 Schedule::invalidateOutputPorts( raft::kernel *kernel )
 {
-   
+
    auto &output_ports( kernel->output );
    for( auto &port : output_ports )
-   {  
+   {
       port.invalidate();
    }
    return;
 }
 
 raft::kstatus
-Schedule::checkSystemSignal( raft::kernel * const kernel, 
+Schedule::checkSystemSignal( raft::kernel * const kernel,
                              void *data,
                              SystemSignalHandler &handlers )
 {
@@ -73,10 +78,10 @@ Schedule::checkSystemSignal( raft::kernel * const kernel,
       {
          port.signal_pop();
          /**
-          * TODO, right now there is special behavior for term signal only, 
+          * TODO, right now there is special behavior for term signal only,
           * what should we do with others?  Need to decide that.
           */
-         
+
          if( handlers.callHandler( curr_signal,
                                port,
                                kernel,
@@ -167,8 +172,8 @@ Schedule::kernelRun( raft::kernel * const kernel,
          invalidateOutputPorts( kernel );
          finished = true;
       }
-   } 
-   /** 
+   }
+   /**
     * must recheck data items again after port valid check, there could
     * have been a push between these two conditional statements.
     */
@@ -190,7 +195,7 @@ Schedule::setPtrSets( raft::kernel * const kernel,
     assert( out != nullptr );
     assert( peekset != nullptr );
     /**
-     * looks a bit odd initially, but the same 
+     * looks a bit odd initially, but the same
      * peekset is set for each kernel's FIFO's
      * within the view of the kernel they'll be
      * accessed sequentially so no contention
@@ -221,7 +226,7 @@ Schedule::fifo_gc( ptr_map_t * const in,
         {
             void *ptr = reinterpret_cast< void* >( (*in_begin).first );
             (*in_begin).second( ptr );
-            ++in_begin;     
+            ++in_begin;
         }
         else
         {
@@ -233,7 +238,7 @@ Schedule::fifo_gc( ptr_map_t * const in,
     {
             void *ptr = reinterpret_cast< void* >( (*in_begin).first );
             (*in_begin).second( ptr );
-            ++in_begin;     
+            ++in_begin;
     }
     in->clear();
     out->clear();

--- a/src/stdalloc.cpp
+++ b/src/stdalloc.cpp
@@ -1,13 +1,13 @@
 /**
- * stdalloc.cpp - simple allocation, just initializes the FIFO with a 
+ * stdalloc.cpp - simple allocation, just initializes the FIFO with a
  * fixed size buffer (512 items) with an alignment of 16-bytes.  This
- * can easily be changed by changing the constants below.  
+ * can easily be changed by changing the constants below.
  *
  * @author: Jonathan Beard
  * @version: Sat Sep 20 19:56:49 2014
- * 
+ *
  * Copyright 2014 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -28,7 +28,7 @@
 #include "port_info.hpp"
 #include "ringbuffertypes.hpp"
 
-stdalloc::stdalloc( raft::map &map, 
+stdalloc::stdalloc( raft::map &map,
                     volatile bool &exit_alloc) : Allocate( map, exit_alloc )
 {
 }
@@ -40,10 +40,12 @@ stdalloc::~stdalloc()
 void
 stdalloc::run()
 {
-   auto alloc_func = [&]( PortInfo &a, 
-                          PortInfo &b, 
+   auto alloc_func = [&]( PortInfo &a,
+                          PortInfo &b,
                           void *data )
    {
+      (void) data;
+
       assert( a.type == b.type );
       /** assume everyone needs a heap for the moment to get working **/
       instr_map_t *func_map( a.const_map[ Type::Heap ] );
@@ -52,15 +54,15 @@ stdalloc::run()
       /** check and see if a has a defined allocation **/
       if( a.existing_buffer != nullptr )
       {
-         fifo = test_func( a.nitems, 
-                           a.start_index, 
-                           a.existing_buffer );     
+         fifo = test_func( a.nitems,
+                           a.start_index,
+                           a.existing_buffer );
       }
       else
       {
          /** check for pre-existing alloc size for test purposes **/
-         fifo = test_func( a.fixed_buffer_size != 0 ? 
-                              a.fixed_buffer_size : 4 /** size **/, 
+         fifo = test_func( a.fixed_buffer_size != 0 ?
+                              a.fixed_buffer_size : 4 /** size **/,
                            16 /** align **/,
                            nullptr /* data struct **/);
       }

--- a/testsuite/allocatePopExternal.cpp
+++ b/testsuite/allocatePopExternal.cpp
@@ -4,9 +4,9 @@
  *
  * @author: Jonathan Beard
  * @version: Sat Feb 27 19:10:26 2016
- * 
+ *
  * Copyright 2016 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -30,10 +30,11 @@
 template < std::size_t N > struct foo
 {
    foo() : length( N ){}
-   
+
    foo( const foo &other ) : length( other.length )
    {
-        for( auto i( 0 ); i < N; i++ )
+        using index_type = std::remove_const_t<decltype(N)>;
+        for( index_type i( 0 ); i < N; i++ )
         {
             pad[ i ] = other.pad[ i ];
         }
@@ -94,10 +95,12 @@ public:
     {
         obj_t mem;
         input[ "x" ].pop( mem );
-        for( auto i( 0 ); i < mem.length; i++ )
+
+        using index_type = std::remove_const_t<decltype(mem.length)>;
+        for( index_type i( 0 ); i < mem.length; i++ )
         {
             //will fail if we've messed something up
-            assert( mem.pad[ i ] == counter );
+            assert( static_cast<std::size_t>(mem.pad[ i ]) == counter );
         }
         counter++;
         return( raft::proceed );
@@ -112,7 +115,7 @@ main( int argc, char **argv )
 {
     start s;
     last l;
-    
+
     raft::map M;
     M += s >> l;
     M.exe();

--- a/testsuite/allocatePopInternal.cpp
+++ b/testsuite/allocatePopInternal.cpp
@@ -1,10 +1,10 @@
 /**
- * allocateSendPush.cpp - 
+ * allocateSendPush.cpp -
  * @author: Jonathan Beard
  * @version: Sat Feb 27 19:10:26 2016
- * 
+ *
  * Copyright 2016 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -69,7 +69,7 @@ public:
     {
         obj_t in;
         input[ "x" ].pop( in );
-        assert( in == counter++ );
+        assert( static_cast<std::size_t>(in) == counter++ );
         return( raft::proceed );
     }
 
@@ -82,7 +82,7 @@ main( int argc, char **argv )
 {
     start s;
     last l;
-    
+
     raft::map M;
     M += s >> l;
     M.exe();

--- a/testsuite/allocatePopInternalObject.cpp
+++ b/testsuite/allocatePopInternalObject.cpp
@@ -4,9 +4,9 @@
  *
  * @author: Jonathan Beard
  * @version: Sat Feb 27 19:10:26 2016
- * 
+ *
  * Copyright 2016 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -30,10 +30,11 @@
 template < std::size_t N > struct foo
 {
    foo() : length( N ){}
-   
+
    foo( const foo &other ) : length( other.length )
    {
-        for( auto i( 0 ); i < N; i++ )
+        using index_type = std::remove_const_t<decltype(N)>;
+        for( index_type i( 0 ); i < N; i++ )
         {
             pad[ i ] = other.pad[ i ];
         }
@@ -94,10 +95,12 @@ public:
     {
         obj_t mem;
         input[ "x" ].pop( mem );
-        for( auto i( 0 ); i < mem.length; i++ )
+
+        using index_type = std::remove_const_t<decltype(mem.length)>;
+        for( index_type i( 0 ); i < mem.length; i++ )
         {
             //will fail if we've messed something up
-            assert( mem.pad[ i ] == counter );
+            assert( static_cast<std::size_t>(mem.pad[ i ]) == counter );
         }
         counter++;
         return( raft::proceed );
@@ -112,7 +115,7 @@ main( int argc, char **argv )
 {
     start s;
     last l;
-    
+
     raft::map M;
     M += s >> l;
     M.exe();

--- a/testsuite/allocatePopPush.cpp
+++ b/testsuite/allocatePopPush.cpp
@@ -1,10 +1,10 @@
 /**
- * allocateSendPush.cpp - 
+ * allocateSendPush.cpp -
  * @author: Jonathan Beard
  * @version: Sat Feb 27 19:10:26 2016
- * 
+ *
  * Copyright 2016 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -28,10 +28,11 @@
 template < std::size_t N > struct foo
 {
    foo() : length( N ){}
-   
+
    foo( const foo &other ) : length( other.length )
    {
-        for( auto i( 0 ); i < N; i++ )
+        using index_type = std::remove_const_t<decltype(N)>;
+        for( index_type i( 0 ); i < N; i++ )
         {
             pad[ i ] = other.pad[ i ];
         }
@@ -110,10 +111,12 @@ public:
     virtual raft::kstatus run()
     {
         auto &mem( input[ "x" ].peek< obj_t >() );
-        for( auto i( 0 ); i < mem.length; i++ )
+
+        using index_type = std::remove_const_t<decltype(mem.length)>;
+        for( index_type i( 0 ); i < mem.length; i++ )
         {
             //will fail if we've messed something up
-            assert( mem.pad[ i ] == counter );
+            assert( static_cast<std::size_t>(mem.pad[ i ]) == counter );
         }
         input[ "x" ].unpeek();
         input[ "x" ].recycle();
@@ -131,7 +134,7 @@ main( int argc, char **argv )
     start s;
     middle m;
     last l;
-    
+
     raft::map M;
     M += s >> m >> l;
     M.exe();

--- a/testsuite/allocateSendPush.cpp
+++ b/testsuite/allocateSendPush.cpp
@@ -1,10 +1,10 @@
 /**
- * allocateSendPush.cpp - 
+ * allocateSendPush.cpp -
  * @author: Jonathan Beard
  * @version: Sat Feb 27 19:10:26 2016
- * 
+ *
  * Copyright 2016 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -28,10 +28,11 @@
 template < std::size_t N > struct foo
 {
    foo() : length( N ){}
-   
+
    foo( const foo &other ) : length( other.length )
    {
-        for( auto i( 0 ); i < N; i++ )
+        using index_type = std::remove_const_t<decltype(N)>;
+        for( index_type i( 0 ); i < N; i++ )
         {
             pad[ i ] = other.pad[ i ];
         }
@@ -114,7 +115,7 @@ public:
         for( auto i( 0 ); i < mem.length; i++ )
         {
             //will fail if we've messed something up
-            assert( mem.pad[ i ] == counter );
+            assert( static_cast<std::size_t>(mem.pad[ i ]) == counter );
         }
         input[ "x" ].unpeek();
         input[ "x" ].recycle();
@@ -132,7 +133,7 @@ main( int argc, char **argv )
     start s;
     middle m;
     last l;
-    
+
     raft::map M;
     M += s >> m >> l;
     M.exe();

--- a/testsuite/allocateSendRandomPush.cpp
+++ b/testsuite/allocateSendRandomPush.cpp
@@ -1,10 +1,10 @@
 /**
- * allocateSendPush.cpp - 
+ * allocateSendPush.cpp -
  * @author: Jonathan Beard
  * @version: Sat Feb 27 19:10:26 2016
- * 
+ *
  * Copyright 2016 Jonathan Beard
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
@@ -28,10 +28,11 @@
 template < std::size_t N > struct foo
 {
    foo() : length( N ){}
-   
+
    foo( const foo &other ) : length( other.length )
    {
-        for( auto i( 0 ); i < N; i++ )
+        using index_type = std::remove_const_t<decltype(N)>;
+        for( index_type i( 0 ); i < N; i++ )
         {
             pad[ i ] = other.pad[ i ];
         }
@@ -124,7 +125,7 @@ public:
         for( auto i( 0 ); i < mem.length; i++ )
         {
             //will fail if we've messed something up
-            assert( mem.pad[ i ] == counter );
+            assert( static_cast<std::size_t>(mem.pad[ i ]) == counter );
         }
         input[ "x" ].unpeek();
         input[ "x" ].recycle();
@@ -142,7 +143,7 @@ main( int argc, char **argv )
     start s;
     middle m;
     last l;
-    
+
     raft::map M;
     M += s >> m >> l;
     M.exe();


### PR DESCRIPTION
Hello, 

I wanted to contribute to RaftLib after attending your talk at C++Now, starting by removing the `clone()` macro. 

Before doing that, though, I noticed that warnings were not enabled by default - I've enabled `-Wall`, `-Wextra` and `-Wpedantic` for `g++` and `clang++`.

I was overwhelmed with the amount of displayed warnings, and did my best to fix them. I temporarily enabled `-Wno-unused-parameters` because I am not sure whether or not you like the `(void) x;` solution or you would prefer the parameter to be unnamed in the function signature.

Some breaking changes had to be introduced to make the code standard compliant, as unnamed structs are not allowed in ISO C++. The `struct` containing `count` and `blocked` is now instantiated as `.bec`. It should be extremely easy to rename it, if you prefer something else. The same thing was done with a struct containing `a` and `b` in some function - it is now instantiated as `.ab`.

I noticed it a little late, but my IDE also removed all trailing spaces - hope that's OK.

